### PR TITLE
fix: allow null group in event form

### DIFF
--- a/web/src/components/EventForm.tsx
+++ b/web/src/components/EventForm.tsx
@@ -6,7 +6,7 @@ import styles from '../styles/Page.module.css'
 type EventFormProps = {
   cancelTo: string
   error: string
-  group?: Group
+  group: Group | null
   groupError?: string
   initialValue?: PaymentEventInput
   submitting: boolean


### PR DESCRIPTION
# HOTFIX: Allow null group in EventForm