### PR TITLE
feat: グループページのUIを刷新

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { Layout } from './components/Layout'
 import HomePage from './pages/HomePage'
 import GroupPage from './pages/GroupPage'
+import GroupDashboardPage from './pages/GroupDashboardPage'
 import EventsListPage from './pages/EventsListPage'
 import NewEventPage from './pages/NewEventPage'
 import EventDetailPage from './pages/EventDetailPage'
@@ -14,7 +15,8 @@ export default function App() {
       <Routes>
         <Route element={<Layout />}>
           <Route index element={<HomePage />} />
-          <Route path="groups/:groupId" element={<GroupPage />}>            
+          <Route path="groups/:groupId" element={<GroupPage />}>
+            <Route index element={<GroupDashboardPage />} />
             <Route path="events" element={<EventsListPage />} />
             <Route path="events/new" element={<NewEventPage />} />
             <Route path="events/:eventId" element={<EventDetailPage />} />

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,14 +1,34 @@
+import { useRef } from 'react'
 import { Link, Outlet } from 'react-router-dom'
 import styles from '../styles/Layout.module.css'
 
 export function Layout() {
+  const menuRef = useRef<HTMLDetailsElement>(null)
+
+  const closeMenu = () => {
+    menuRef.current?.removeAttribute('open')
+  }
+
   return (
     <div className={styles.container}>
       <header className={styles.header}>
-        <div className={styles.brand}>GoDutch</div>
-        <nav className={styles.nav}>
-          <Link to="/" className={styles.navLink}>Home</Link>
-        </nav>
+        <div className={styles.headerContent}>
+          <div className={styles.brand}>GoDutch</div>
+          <details ref={menuRef} className={styles.menu}>
+            <summary className={styles.menuButton} aria-label="メニュー">
+              <span className={styles.menuIcon} aria-hidden="true">
+                <span />
+                <span />
+                <span />
+              </span>
+            </summary>
+            <nav className={styles.menuPanel} aria-label="メインメニュー">
+              <Link to="/" className={styles.menuLink} onClick={closeMenu}>
+                新規グループ作成
+              </Link>
+            </nav>
+          </details>
+        </div>
       </header>
       <main className={styles.main}>
         <Outlet />

--- a/web/src/pages/GroupDashboardPage.tsx
+++ b/web/src/pages/GroupDashboardPage.tsx
@@ -1,0 +1,90 @@
+import { generatePath, useOutletContext, useParams } from 'react-router-dom'
+import { useRef, useState } from 'react'
+import type { GroupOutletContext } from './GroupPage'
+import styles from '../styles/Page.module.css'
+
+function formatAmount(value?: string) {
+  if (!value) return '0'
+  try {
+    return BigInt(value).toLocaleString('ja-JP')
+  } catch {
+    return value
+  }
+}
+
+export default function GroupDashboardPage() {
+  const { groupId = '' } = useParams()
+  const { group } = useOutletContext<GroupOutletContext>()
+  const [copied, setCopied] = useState(false)
+  const [manualCopy, setManualCopy] = useState(false)
+  const manualCopyRef = useRef<HTMLInputElement | null>(null)
+  const groupPath = generatePath('/groups/:groupId', { groupId })
+  const pageUrl =
+    typeof window !== 'undefined'
+      ? new URL(groupPath, window.location.origin).toString()
+      : groupPath
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(pageUrl)
+      setCopied(true)
+      setManualCopy(false)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      setManualCopy(true)
+      const input = manualCopyRef.current
+      if (input) {
+        requestAnimationFrame(() => {
+          input.focus()
+          input.select()
+        })
+      }
+    }
+  }
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.card}>
+        <h2 className={styles.h2}>{group.name}</h2>
+        {group.description && <p className={styles.desc}>{group.description}</p>}
+        <div className={styles.totalPaid}>
+          <span className={styles.totalPaidLabel}>グループ全体の支払総額</span>
+          <span className={styles.totalPaidAmount}>{formatAmount(group.totalPaidAmount)}円</span>
+        </div>
+        <div className={styles.shareRow}>
+          <span className={styles.shareUrl}>
+            URL: <a href={pageUrl}>{pageUrl}</a>
+          </span>
+          <button type="button" className={styles.secondaryBtn} onClick={handleCopy}>
+            コピー
+          </button>
+          {copied && <span role="status">コピーしました</span>}
+        </div>
+        {manualCopy && (
+          <div className={styles.desc}>
+            <p className={styles.help} role="status">
+              コピーAPIが使用できません。下のURLは選択済みです。Cmd+C（または長押し）でコピーしてください。
+            </p>
+            <input
+              ref={manualCopyRef}
+              value={pageUrl}
+              readOnly
+              className={styles.input}
+              onFocus={(e) => e.currentTarget.select()}
+            />
+          </div>
+        )}
+        <section>
+          <h3 className={styles.h3}>メンバー</h3>
+          <ul className={styles.list}>
+            {group.members.map((member) => (
+              <li key={member.id} className={styles.listItem}>
+                {member.name}
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </section>
+  )
+}

--- a/web/src/pages/GroupPage.tsx
+++ b/web/src/pages/GroupPage.tsx
@@ -1,44 +1,16 @@
-import { generatePath, Link, Outlet, useLocation, useParams } from 'react-router-dom'
-import { useState, useRef } from 'react'
+import { Link, NavLink, Outlet, useLocation, useParams } from 'react-router-dom'
+import type { Group } from '../api'
 import { useGroup } from '../hooks/useGroup'
 import styles from '../styles/Page.module.css'
 
-function formatAmount(value?: string) {
-  if (!value) return '0'
-  try {
-    return BigInt(value).toLocaleString('ja-JP')
-  } catch {
-    return value
-  }
+export interface GroupOutletContext {
+  group: Group
 }
 
 export default function GroupPage() {
   const { groupId = '' } = useParams()
   const location = useLocation()
   const { group, loading, error } = useGroup(groupId, location.key)
-  const [copied, setCopied] = useState(false)
-  const [manualCopy, setManualCopy] = useState(false)
-  const manualCopyRef = useRef<HTMLInputElement | null>(null)
-  const groupPath = generatePath('/groups/:groupId', { groupId })
-  const pageUrl = typeof window !== 'undefined' ? new URL(groupPath, window.location.origin).toString() : groupPath
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(pageUrl)
-      setCopied(true)
-      setManualCopy(false)
-      setTimeout(() => setCopied(false), 1500)
-    } catch {
-      setManualCopy(true)
-      const input = manualCopyRef.current
-      if (input) {
-        requestAnimationFrame(() => {
-          input.focus()
-          input.select()
-        })
-      }
-    }
-  }
 
   if (loading && !group) return <p>読み込み中...</p>
   if (error)
@@ -55,50 +27,21 @@ export default function GroupPage() {
   if (!group) return null
 
   return (
-    <section className={styles.section}>
-      <div className={styles.card}>
-        <h2 className={styles.h2}>{group.name}</h2>
-        {group.description && <p className={styles.desc}>{group.description}</p>}
-        <div className={styles.totalPaid}>
-          <span className={styles.totalPaidLabel}>グループ全体の支払総額</span>
-          <span className={styles.totalPaidAmount}>{formatAmount(group.totalPaidAmount)}円</span>
-        </div>
-        <div
-          className={styles.desc}
-          style={{ display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' }}
-        >
-          <span>
-            URL: <a href={pageUrl}>{pageUrl}</a>
-          </span>
-          <button type="button" className={styles.secondaryBtn} onClick={handleCopy}>コピー</button>
-          {copied && <span role="status">コピーしました</span>}
-        </div>
-        {manualCopy && (
-          <div className={styles.desc}>
-            <p className={styles.help} role="status">コピーAPIが使用できません。下のURLは選択済みです。Cmd+C（または長押し）でコピーしてください。</p>
-            <input
-              ref={manualCopyRef}
-              value={pageUrl}
-              readOnly
-              className={styles.input}
-              onFocus={(e) => e.currentTarget.select()}
-            />
-          </div>
-        )}
-        <section>
-          <h3 className={styles.h3}>メンバー</h3>
-          <ul className={styles.list}>
-            {group.members.map((m) => (
-              <li key={m.id} className={styles.listItem}>{m.name}</li>
-            ))}
-          </ul>
-        </section>
-        <nav className={styles.tabs}>
-          <Link to="events" className={styles.tab}>支払いイベント</Link>
-          <Link to="settlement" className={styles.tab}>清算結果</Link>
+    <>
+      <div className={styles.groupNavContainer}>
+        <nav className={styles.tabs} aria-label={`${group.name}のメニュー`}>
+          <NavLink to="." end className={styles.tab}>
+            ダッシュボード
+          </NavLink>
+          <NavLink to="events" className={styles.tab}>
+            支払いイベント
+          </NavLink>
+          <NavLink to="settlement" className={styles.tab}>
+            精算結果
+          </NavLink>
         </nav>
       </div>
-      <Outlet />
-    </section>
+      <Outlet context={{ group } satisfies GroupOutletContext} />
+    </>
   )
 }

--- a/web/src/styles/Layout.module.css
+++ b/web/src/styles/Layout.module.css
@@ -22,21 +22,29 @@
 }
 
 @layer components {
-  .container { min-height: 100%; display: grid; grid-template-rows: auto 1fr auto; }
+  .container { width: 100%; min-width: 0; min-height: 100%; display: grid; grid-template-rows: auto 1fr auto; overflow-x: hidden; }
   .header {
     position: sticky; top: 0; z-index: 10;
     background: var(--bg); border-bottom: 1px solid var(--border);
     box-shadow: var(--shadow);
   }
-  .brand { max-width: var(--max-w); margin: 0 auto; padding: 10px var(--pad); font-weight: 700; letter-spacing: .2px; }
-  .nav { max-width: var(--max-w); margin: 0 auto; padding: 0 var(--pad) var(--pad); display: flex; gap: 12px; }
-  .navLink { color: #06c; }
-  .main { max-width: var(--max-w); margin: 0 auto; padding: var(--pad-lg) var(--pad); }
+  .headerContent { width: 100%; max-width: var(--max-w); margin: 0 auto; padding: 10px var(--pad); display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+  .brand { font-weight: 700; letter-spacing: .2px; }
+  .menu { position: relative; }
+  .menuButton { width: 44px; height: 44px; display: grid; place-items: center; border-radius: 10px; cursor: pointer; list-style: none; -webkit-tap-highlight-color: transparent; }
+  .menuButton::-webkit-details-marker { display: none; }
+  .menuButton:hover { background: var(--bg-soft); }
+  .menuButton:focus-visible { outline: 2px solid #0071e3; outline-offset: 2px; }
+  .menuIcon { width: 22px; display: grid; gap: 4px; }
+  .menuIcon span { display: block; width: 100%; height: 2px; border-radius: 999px; background: #1d1d1f; }
+  .menuPanel { position: absolute; top: calc(100% + 8px); right: 0; min-width: 200px; padding: 8px; border: 1px solid var(--border); border-radius: 12px; background: var(--bg); box-shadow: var(--shadow); }
+  .menuLink { display: block; padding: 10px 12px; border-radius: 8px; color: #06c; white-space: nowrap; }
+  .menuLink:hover, .menuLink:focus-visible { background: var(--bg-soft); }
+  .main { width: 100%; min-width: 0; max-width: var(--max-w); margin: 0 auto; padding: var(--pad-lg) var(--pad); }
   .footer { max-width: var(--max-w); margin: 0 auto; padding: 32px var(--pad); color: var(--muted); border-top: 1px solid var(--border); }
 
   @media (min-width: 768px) {
-    .brand { padding: 14px var(--pad); }
-    .nav { padding-bottom: var(--pad-lg); }
+    .headerContent { padding-top: 14px; padding-bottom: 14px; }
   }
 }
 
@@ -50,5 +58,6 @@
     --shadow: none;
   }
   body { color: #ffffff; background: #000000; }
-  .navLink { color: #5eb1ff; }
+  .menuIcon span { background: #fff; }
+  .menuLink { color: #5eb1ff; }
 }

--- a/web/src/styles/Page.module.css
+++ b/web/src/styles/Page.module.css
@@ -116,6 +116,8 @@
 
 /* Generic page section (alias for pageSection usage in other pages) */
 .section {
+  width: 100%;
+  min-width: 0;
   margin: 16px auto 0;
   padding-left: max(16px, env(safe-area-inset-left));
   padding-right: max(16px, env(safe-area-inset-right));
@@ -190,6 +192,8 @@
 .textarea,
 select {
   appearance: none;
+  font: inherit;
+  font-size: 16px;
   width: 100%;
   border: 1px solid var(--border);
   border-radius: 12px;
@@ -245,16 +249,24 @@ select {
 }
 .link:hover { text-decoration: underline; }
 
+.groupNavContainer {
+  margin: 0 auto;
+  padding: 0 max(16px, env(safe-area-inset-right)) 0 max(16px, env(safe-area-inset-left));
+  max-width: 960px;
+  overflow-x: auto;
+}
+
 .tabs {
-  margin: 12px 0 8px;
   display: flex;
-  gap: 12px;
+  gap: 20px;
   border-bottom: 1px solid var(--border);
+  min-width: max-content;
 }
 
 .tab {
-  padding: 8px 2px;
+  padding: 10px 2px;
   color: var(--text-subtle);
+  font-weight: 600;
   text-decoration: none;
   border-bottom: 2px solid transparent;
 }
@@ -265,6 +277,21 @@ select {
 .tab[aria-current="page"] {
   color: var(--text);
   border-color: #06c;
+}
+
+.shareRow {
+  margin: 0 0 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  color: var(--text-subtle);
+}
+
+.shareUrl {
+  flex: 1 1 320px;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .error {


### PR DESCRIPTION
## 概要

- ヘッダーのHomeリンクをハンバーガーメニューへ置き換え、「新規グループ作成」をメニュー内へ移動
- グループ画面上部に「ダッシュボード / 支払いイベント / 精算結果」の共通ナビゲーションを追加
- グループ概要をダッシュボード用indexルートへ分離し、各画面を切り替えやすい構成に変更
- フォーム要素を16px以上にして、iOS Safariでフォーカス時に自動ズームされる問題を防止
- 長い共有URLを含むコンパクト幅のレイアウトとダークモード時のメニュー視認性を調整

## 確認内容

- `cd web && npm run build` ✅
- `cd web && npx eslint src/App.tsx src/components/Layout.tsx src/pages/GroupPage.tsx src/pages/GroupDashboardPage.tsx` ✅
- `cd web && npm run lint` ⚠️ 今回未変更の `HomePage.tsx`、`worker.ts`、`vite.config.ts` にある既存エラー4件で失敗
- Chromeのコンパクト幅・ダークモードで、ハンバーガー、タブ切替表示、ダッシュボードの収まりを手動確認 ✅
- `git diff --check` ✅

## 補足

- API、DBスキーマ、環境変数の変更はありません。

Closes #15